### PR TITLE
problem-id

### DIFF
--- a/src/main/kotlin/com/leita/leita/controller/problem/ProblemMapper.kt
+++ b/src/main/kotlin/com/leita/leita/controller/problem/ProblemMapper.kt
@@ -1,27 +1,12 @@
 package com.leita.leita.controller.problem
 
-import com.leita.leita.controller.problem.request.CreateProblemRequest
 import com.leita.leita.controller.problem.response.ProblemDetailResponse
 import com.leita.leita.controller.problem.response.ProblemsResponse
-import com.leita.leita.domain.User
 import com.leita.leita.domain.problem.Problem
 import org.springframework.data.domain.Page
 
 class ProblemMapper {
     companion object {
-        fun fromCreateProblemRequest(author: User, request: CreateProblemRequest): Problem {
-            val problem = Problem.create(
-                title = request.title,
-                author,
-                description = request.description,
-                limit = request.limit,
-                testCases = request.testCases,
-                source = request.source,
-                category = request.category
-            )
-            return problem.addTestCases(request.testCases)
-        }
-
         fun toProblemsResponse(problems: Page<Problem>): ProblemsResponse {
             return ProblemsResponse(
                 content = problems.content.map { toProblemDetailResponse(it) },
@@ -34,7 +19,7 @@ class ProblemMapper {
 
         fun toProblemDetailResponse(problem: Problem): ProblemDetailResponse {
             return ProblemDetailResponse(
-                problemId = problem.id,
+                problemId = problem.problemId,
                 title = problem.title,
                 authorName = problem.author.name,
                 description = problem.description,

--- a/src/main/kotlin/com/leita/leita/domain/judge/Judge.kt
+++ b/src/main/kotlin/com/leita/leita/domain/judge/Judge.kt
@@ -37,6 +37,27 @@ open class Judge(
     @Enumerated(EnumType.STRING)
     open val type: JudgeType
 ) : BaseEntity() {
+
+    companion object {
+        fun create(
+            problemId: Long,
+            user: User,
+            language: Language,
+            type: JudgeType
+        ): Judge {
+            return Judge(
+                problemId,
+                user,
+                used = UsedInfo(
+                    memory = 0,
+                    time = 0,
+                    language,
+                ),
+                type = type
+            )
+        }
+    }
+
     fun updateSizeOfCode(code: String) {
         this.sizeOfCode = Base64.getDecoder().decode(code).size.toLong()
     }

--- a/src/main/kotlin/com/leita/leita/domain/problem/Problem.kt
+++ b/src/main/kotlin/com/leita/leita/domain/problem/Problem.kt
@@ -1,8 +1,10 @@
 package com.leita.leita.domain.problem
 
+import com.leita.leita.common.exception.CustomException
 import com.leita.leita.domain.User
 import com.leita.leita.repository.BaseEntity
 import jakarta.persistence.*
+import org.springframework.http.HttpStatus
 import kotlin.random.Random
 
 @Entity
@@ -62,7 +64,9 @@ open class Problem(
             category: List<String>,
             problemId: Long = generateProblemId()
         ): Problem {
-            require(testCases.size >= 5) { "테스트 케이스는 최소 5개 이상이어야 합니다." }
+            if(testCases.size < 5) {
+                throw CustomException("테스트 케이스는 최소 5개 이상이어야 합니다.", HttpStatus.BAD_REQUEST)
+            }
 
             val problem = Problem(
                 title = title,

--- a/src/main/kotlin/com/leita/leita/domain/problem/Problem.kt
+++ b/src/main/kotlin/com/leita/leita/domain/problem/Problem.kt
@@ -3,6 +3,7 @@ package com.leita.leita.domain.problem
 import com.leita.leita.domain.User
 import com.leita.leita.repository.BaseEntity
 import jakarta.persistence.*
+import kotlin.random.Random
 
 @Entity
 @Table(name = "problem")
@@ -43,7 +44,10 @@ open class Problem(
     @ElementCollection
     @CollectionTable(name = "problem_category", joinColumns = [JoinColumn(name = "problem_id")])
     @Column(name = "category")
-    open var category: MutableList<String> = mutableListOf()
+    open var category: MutableList<String> = mutableListOf(),
+
+    @Column(nullable = false)
+    open val problemId: Long
 
 ) : BaseEntity() {
 
@@ -55,7 +59,8 @@ open class Problem(
             limit: Limit,
             testCases: List<TestCase>,
             source: String,
-            category: List<String>
+            category: List<String>,
+            problemId: Long = generateProblemId()
         ): Problem {
             require(testCases.size >= 5) { "테스트 케이스는 최소 5개 이상이어야 합니다." }
 
@@ -65,7 +70,8 @@ open class Problem(
                 description = description,
                 limit = limit,
                 source = source,
-                solved = Solved(0, 0, 0.0)
+                solved = Solved(0, 0, 0.0),
+                problemId = problemId
             )
 
             testCases.forEach { it.withProblem(problem) }
@@ -73,6 +79,21 @@ open class Problem(
             problem.category.addAll(category)
 
             return problem
+        }
+
+        fun generateProblemId(): Long {
+            return Random.nextInt(10000, 100000).toLong()
+        }
+
+        fun generateProblemId(excludeProblemId: Long): Long {
+            val maxAttempts = 10
+            repeat(maxAttempts) {
+                val problemId = Random.nextInt(10000, 100000).toLong()
+                if(!problemId.equals(excludeProblemId)) {
+                    return problemId
+                }
+            }
+            throw IllegalStateException("문제 ID 생성 실패: $maxAttempts 회 시도 중 중복 발생")
         }
     }
 
@@ -95,12 +116,6 @@ open class Problem(
 
         this.category.clear()
         this.category.addAll(category)
-    }
-
-    fun addTestCases(newTestCases: List<TestCase>): Problem {
-        newTestCases.forEach { it.withProblem(this) }
-        this.testCases.addAll(newTestCases)
-        return this
     }
 
     fun filterVisibleTestCases(): Problem {

--- a/src/main/kotlin/com/leita/leita/domain/problem/TestCase.kt
+++ b/src/main/kotlin/com/leita/leita/domain/problem/TestCase.kt
@@ -5,7 +5,7 @@ import com.leita.leita.repository.BaseEntity
 import jakarta.persistence.*
 
 @Entity
-@Table(indexes = [Index(name = "idx_testcase_isshow", columnList = "is_show")], name = "problem_test_cases")
+@Table(name = "problem_test_cases")
 @Access(AccessType.FIELD)
 open class TestCase(
 
@@ -16,7 +16,6 @@ open class TestCase(
     open var output: String,
 
     @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
     open var isShow: Boolean
 
 ) : BaseEntity() {
@@ -32,10 +31,12 @@ open class TestCase(
         return this
     }
 
+    @JsonIgnore
     fun show() {
         this.isShow = true
     }
 
+    @JsonIgnore
     fun hide() {
         this.isShow = false
     }

--- a/src/main/kotlin/com/leita/leita/domain/study/StudyClass.kt
+++ b/src/main/kotlin/com/leita/leita/domain/study/StudyClass.kt
@@ -1,11 +1,13 @@
 package com.leita.leita.domain.study
 
+import com.leita.leita.common.exception.CustomException
 import com.leita.leita.domain.User
 import com.leita.leita.repository.BaseEntity
 import jakarta.persistence.*
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
+import org.springframework.http.HttpStatus
 
 @Entity
 @Table(name = "study_class")
@@ -54,8 +56,9 @@ open class StudyClass(
             requirement: String,
             admin: User
         ): StudyClass {
-            require(title.isNotBlank()) { "스터디 제목은 필수입니다." }
-            require(description.isNotBlank()) { "스터디 설명은 필수입니다." }
+            if( requirement.isBlank() || description.isBlank() ) {
+                throw CustomException("스터디 요건은 필수입니다.", HttpStatus.BAD_REQUEST)
+            }
 
             val study = StudyClass(
                 title = title,

--- a/src/main/kotlin/com/leita/leita/repository/ProblemRepository.kt
+++ b/src/main/kotlin/com/leita/leita/repository/ProblemRepository.kt
@@ -69,5 +69,7 @@ interface ProblemRepository : JpaRepository<Problem, Long> {
         pageable: Pageable
     ): Page<Problem>
 
-    fun findProblemById(problemId: Long): Problem?
+    fun findProblemByProblemId(problemId: Long): Problem?
+
+    fun existsProblemByProblemId(problemId: Long): Boolean
 }

--- a/src/main/kotlin/com/leita/leita/service/JudgeService.kt
+++ b/src/main/kotlin/com/leita/leita/service/JudgeService.kt
@@ -10,11 +10,11 @@ import com.leita.leita.controller.dto.judge.response.RunResponse
 import com.leita.leita.domain.judge.Judge
 import com.leita.leita.domain.judge.JudgeType
 import com.leita.leita.domain.judge.Result
-import com.leita.leita.domain.judge.UsedInfo
 import com.leita.leita.port.judge.JudgePort
 import com.leita.leita.port.judge.dto.response.JudgeWCResponse
 import com.leita.leita.port.judge.dto.response.RunWCResponse
 import com.leita.leita.repository.JudgeRepository
+import com.leita.leita.repository.ProblemRepository
 import com.leita.leita.repository.UserRepository
 import jakarta.transaction.Transactional
 import org.springframework.http.HttpStatus
@@ -26,26 +26,18 @@ class JudgeService(
     private val judgeRepository: JudgeRepository,
     private val jwtUtils: JwtUtils,
     private val userRepository: UserRepository,
-    private val problemService: ProblemService
+    private val problemService: ProblemService,
+    private val problemRepository: ProblemRepository
 ) {
     @Transactional
     fun submit(problemId: Long, request: SubmitRequest): SubmitResponse {
         val email = jwtUtils.extractEmail()
         val user = userRepository.findByEmail(email)
             ?: throw CustomException("User not found with email: $email", HttpStatus.UNAUTHORIZED)
-        judgeRepository.findById(problemId)
+        val problem = problemRepository.findProblemByProblemId(problemId)
             ?: throw CustomException("Problem with id: $problemId not found", HttpStatus.NOT_FOUND)
 
-        val submit = Judge(
-            problemId,
-            user,
-            used = UsedInfo(
-                memory = 0,
-                time = 0,
-                language = request.language,
-            ),
-            type = JudgeType.SUBMIT
-        )
+        val submit = Judge.create(problem.id, user, request.language, JudgeType.SUBMIT)
         val submitId = judgeRepository.save(submit).id
 
         val response: JudgeWCResponse = judgePort.submit(problemId, submitId, request)
@@ -62,20 +54,11 @@ class JudgeService(
         val email = jwtUtils.extractEmail()
         val user = userRepository.findByEmail(email)
             ?: throw CustomException("User not found with email: $email", HttpStatus.UNAUTHORIZED)
-        judgeRepository.findById(problemId)
+        val problem = problemRepository.findProblemByProblemId(problemId)
             ?: throw CustomException("Problem with id: $problemId not found", HttpStatus.NOT_FOUND)
 
-        val submit = Judge(
-            problemId,
-            user,
-            used = UsedInfo(
-                memory = 0,
-                time = 0,
-                language = request.language,
-            ),
-            type = JudgeType.RUN
-        )
-        val submitId = judgeRepository.save(submit).id
+        val run = Judge.create(problem.id, user, request.language, JudgeType.RUN)
+        val submitId = judgeRepository.save(run).id
 
         val response: List<RunWCResponse> = judgePort.run(problemId, submitId, request)
         return JudgeMapper.toRunResponse(response)
@@ -83,7 +66,9 @@ class JudgeService(
 
     fun getJudges(problemId: Long?): List<Judge> {
         if(problemId != null) {
-            return judgeRepository.findAllByProblemIdAndType(problemId, JudgeType.SUBMIT)
+            val problem = problemRepository.findProblemByProblemId(problemId)
+                ?: throw CustomException("Problem with id: $problemId not found", HttpStatus.NOT_FOUND)
+            return judgeRepository.findAllByProblemIdAndType(problem.id, JudgeType.SUBMIT)
         } else {
             val email = jwtUtils.extractEmail()
             val user = userRepository.findByEmail(email)

--- a/src/main/kotlin/com/leita/leita/service/ProblemService.kt
+++ b/src/main/kotlin/com/leita/leita/service/ProblemService.kt
@@ -9,6 +9,7 @@ import com.leita.leita.controller.problem.response.CreateProblemResponse
 import com.leita.leita.controller.problem.response.DeleteProblemResponse
 import com.leita.leita.controller.problem.response.ProblemDetailResponse
 import com.leita.leita.controller.problem.response.ProblemsResponse
+import com.leita.leita.domain.problem.Problem
 import com.leita.leita.repository.ProblemRepository
 import com.leita.leita.repository.UserRepository
 import org.springframework.data.domain.PageRequest
@@ -27,8 +28,23 @@ class ProblemService(
         val user = userRepository.findByEmail(email)
             ?: throw CustomException("User not found with email: $email", HttpStatus.UNAUTHORIZED)
 
-        val problem = ProblemMapper.fromCreateProblemRequest(user, request)
-        val problemId = problemRepository.save(problem).id
+        var problemId = Problem.generateProblemId()
+        if( problemRepository.existsProblemByProblemId(problemId) ) {
+            problemId = Problem.generateProblemId(problemId)
+        }
+
+        var problem = Problem.create(
+            title = request.title,
+            author = user,
+            description = request.description,
+            limit = request.limit,
+            testCases = request.testCases,
+            source = request.source,
+            category = request.category,
+            problemId
+        )
+        problemRepository.save(problem)
+
         return CreateProblemResponse(problemId)
     }
 
@@ -37,8 +53,8 @@ class ProblemService(
         val user = userRepository.findByEmail(email)
             ?: throw CustomException("User not found with email: $email", HttpStatus.UNAUTHORIZED)
 
-        val problem = problemRepository.findById(problemId)
-            .orElseThrow { CustomException("Problem with id: $problemId not found", HttpStatus.NOT_FOUND) }
+        val problem = problemRepository.findProblemByProblemId(problemId)
+            ?: throw CustomException("Problem with id: $problemId not found", HttpStatus.NOT_FOUND)
         if (problem.author.id != user.id) {
             throw CustomException("Permission denied", HttpStatus.FORBIDDEN)
         }
@@ -56,8 +72,8 @@ class ProblemService(
         val user = userRepository.findByEmail(email)
             ?: throw CustomException("User not found with email: $email", HttpStatus.UNAUTHORIZED)
 
-        val problem = problemRepository.findById(problemId)
-            .orElseThrow { CustomException("Problem with id: $problemId not found", HttpStatus.NOT_FOUND) }
+        val problem = problemRepository.findProblemByProblemId(problemId)
+            ?: throw CustomException("Problem with id: $problemId not found", HttpStatus.NOT_FOUND)
 
         if(problem.author.id != user.id) {
             throw CustomException("Permission denied", HttpStatus.FORBIDDEN)
@@ -89,14 +105,14 @@ class ProblemService(
     }
 
     fun getProblem(problemId: Long): ProblemDetailResponse {
-        val problem = problemRepository.findProblemById(problemId)
+        val problem = problemRepository.findProblemByProblemId(problemId)
             ?: throw CustomException("Problem with id: $problemId not found", HttpStatus.NOT_FOUND)
 
         return ProblemMapper.toProblemDetailResponse(problem.filterVisibleTestCases())
     }
 
     fun updateSolved(problemId: Long, isSolved: Boolean) {
-        val problem = problemRepository.findProblemById(problemId)
+        val problem = problemRepository.findProblemByProblemId(problemId)
             ?: throw CustomException("Problem with id: $problemId not found", HttpStatus.NOT_FOUND)
         problem.solved.updateSolved(isSolved)
         problemRepository.save(problem.filterVisibleTestCases())

--- a/src/test/kotlin/com/leita/leita/ProblemTest.kt
+++ b/src/test/kotlin/com/leita/leita/ProblemTest.kt
@@ -27,7 +27,7 @@ class ProblemTest {
                 limit = limit,
                 testCases = testCases,
                 source = "source",
-                category = listOf("cat")
+                category = listOf("cat"),
             )
         }
         assertThat(exception.message).isEqualTo("테스트 케이스는 최소 5개 이상이어야 합니다.")


### PR DESCRIPTION
1. 5자리 난수의 problemId 추가
    - Problem 생성 시 5자리 난수의 problemId를 생성하도록 수정
    - 내부 로직 및 DB에서는 기존의 primaryKey를 사용하고, 외부 반환 시에 problemId를 반환
2. 정책 미 충족 시 CustomException을 발생하도록 수정
    - as-is : kotlin require()를 사용하여 조건 확인, IllegalArgumentException 발생
    - to-be : if로 조건을 확인하도록 수정하여, CustomException 발생